### PR TITLE
feat: FastAPI 모델 API 생성 및 /generate 엔드포인트 구현

### DIFF
--- a/src/model/textmodel/text_generation.py
+++ b/src/model/textmodel/text_generation.py
@@ -1,10 +1,24 @@
 import os
 from openai import OpenAI
 from dotenv import load_dotenv
+from fastapi import FastAPI
+from pydantic import BaseModel
 
 # 환경 변수 로드
 load_dotenv()
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+# FastAPI 앱 생성
+app = FastAPI()
+
+# 요청 데이터 구조 정의
+class AdRequest(BaseModel):
+    product: str
+    tone: str = "친근한"
+    channel: str = "instagram"
+    target_audience: str | None = None
+    translate_en: bool = False
+
 
 def generate_ad_content(
     product: str,
@@ -21,7 +35,7 @@ def generate_ad_content(
     - target_audience: 타겟 고객 (20대 여성, 직장인 점심 고객 등)
     - translate_en: 영어 번역 포함 여부
     """
-
+    
     channel_map = {
         "instagram": "인스타그램 홍보글 (짧고 매력적인 본문)",
         "blog": "블로그 홍보글 (자세하고 서술적인 글)",
@@ -39,8 +53,7 @@ def generate_ad_content(
     if target_audience:
         prompt += f"\n타겟 고객: {target_audience}"
 
-    prompt += f"""
-
+    prompt += """
     출력 조건:
     - 총 3가지 서로 다른 버전의 홍보 문구를 작성 (A/B 테스트 용도)
     - 각 버전은 구분선(---)으로 나누어 출력
@@ -56,18 +69,25 @@ def generate_ad_content(
     response = client.chat.completions.create(
         model="gpt-4.1-mini",
         messages=[{"role": "user", "content": prompt}],
-        temperature=0.9,  # 다양성을 높이기 위해 온도 조금 올림
+        temperature=0.9,
     )
 
     return response.choices[0].message.content.strip()
 
 
-if __name__ == "__main__":
-    product = input("상품 설명을 입력하세요: ")
-    tone = input("톤앤매너 (예: 친근한, 고급스러운): ")
-    channel = input("채널 (instagram/blog/banner): ").lower() or "instagram"
-    target_audience = input("타겟 고객 (없으면 Enter): ") or None
-    translate = input("영어 번역글 포함? (y/n): ").lower().startswith("y")
+# API 엔드포인트
+@app.post("/generate")
+def generate_ad(request: AdRequest):
+    result = generate_ad_content(
+        request.product,
+        request.tone,
+        request.channel,
+        request.target_audience,
+        request.translate_en
+    )
+    return {"result": result}
 
-    print("\n=== 생성된 광고 콘텐츠 (A/B 테스트용) ===")
-    print(generate_ad_content(product, tone, channel, target_audience, translate))
+
+@app.get("/test")
+def test():
+    return {"status": "ok"}


### PR DESCRIPTION
- 텍스트 모델을 FastAPI 서버로 감싸서 외부에서 POST 요청으로 호출 가능하도록 구현
- /generate 엔드포인트 추가
  - 요청 JSON: product, tone, channel, target_audience, translate_en
  - 응답 JSON: {"result": "..."} 형식으로 광고 문구 3가지 반환
- 테스트용 /test 엔드포인트 추가 (서버 상태 확인용)
- 외부 IP + 포트에서 접근 가능 (curl 테스트 가능)